### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+.editorconfig          export-ignore
+.gitattributes         export-ignore
+/.github/              export-ignore
+.gitignore             export-ignore
+.php-cs-fixer.dist.php export-ignore
+/docs/                 export-ignore
+/Dockerfile            export-ignore
+/Makefile              export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon.dist     export-ignore
+/phpunit.xml.dist      export-ignore
+/psalm-baseline.xml    export-ignore
+/psalm.xml             export-ignore
+/tests/                export-ignore


### PR DESCRIPTION
Adiciona o arquivo .gitattributes com configurações específicas para otimizar o processo de exportação do código (ao adicionar a dependencia), excluindo arquivos e diretórios que não são necessários em ambientes de produção. Garantindo que apenas arquivos necessários para execução em produção sejam incluídos.